### PR TITLE
LeptonInjector Compatibility

### DIFF
--- a/src/DarkNews/MC.py
+++ b/src/DarkNews/MC.py
@@ -265,7 +265,7 @@ class MC_events:
 
         # > differential rate weights
         df_gen["w_event_rate"] = (
-            weights["diff_event_rate"] * const.attobarn_to_cm2 / decay_rates * target_multiplicity * exposure * batch_f.norm["diff_event_rate"]
+            weights["diff_event_rate"] / decay_rates * target_multiplicity * exposure * batch_f.norm["diff_event_rate"]
         )
         
         if self.sparse <= 1:
@@ -283,7 +283,7 @@ class MC_events:
 
         if self.sparse < 4:
             # > flux averaged xsec weights (neglecting kinematics of decay)
-            df_gen["w_flux_avg_xsec"] = weights["diff_flux_avg_xsec"] * const.attobarn_to_cm2 * target_multiplicity * exposure * batch_f.norm["diff_flux_avg_xsec"]
+            df_gen["w_flux_avg_xsec"] = weights["diff_flux_avg_xsec"] * target_multiplicity * exposure * batch_f.norm["diff_flux_avg_xsec"]
 
 
         # Event-by-event descriptors 

--- a/src/DarkNews/MC.py
+++ b/src/DarkNews/MC.py
@@ -437,7 +437,7 @@ def get_samples(integ, batch_integrand, return_jac=False):
         return np.array(unit_samples), weights
 
 
-def run_vegas(batch_f, integ, NINT=10, NEVAL=1000, NINT_warmup=10, NEVAL_warmup=1000, **kwargs):
+def run_vegas(batch_f, integ, NINT=10, NEVAL=1000, NINT_warmup=10, NEVAL_warmup=1000, savestr=None, **kwargs):
     """
     Function that calls vegas evaluations. This function defines the vegas parameters used by
     DarkNews throughout.
@@ -461,4 +461,4 @@ def run_vegas(batch_f, integ, NINT=10, NEVAL=1000, NINT_warmup=10, NEVAL_warmup=
     logger.debug("VEGAS warm-up completed.")
 
     # sample again, now saving result and turning off further adaption
-    return integ(batch_f, nitn=NINT, neval=NEVAL, uses_jac=True, **kwargs)
+    return integ(batch_f, nitn=NINT, neval=NEVAL, uses_jac=True, saveall=savestr, **kwargs)

--- a/src/DarkNews/ModelContainer.py
+++ b/src/DarkNews/ModelContainer.py
@@ -498,7 +498,7 @@ class ModelContainer:
                                                 nu_parent=decay_args["nu_parent"],
                                                 nu_daughter=decay_args["nu_daughter"],
                                                 final_lepton1=decay_pdg,
-                                                final_lepton2=decay_pdg,
+                                                final_lepton2=-decay_pdg,
                                                 h_parent=decay_args["h_parent"],
                                                 TheoryModel=self.bsm_model,
                                             )

--- a/src/DarkNews/ModelContainer.py
+++ b/src/DarkNews/ModelContainer.py
@@ -1,0 +1,577 @@
+import logging
+import logging.handlers
+import sys
+import numpy as np
+import os
+from pathlib import Path
+from particle import literals as lp
+
+# Dark Neutrino and MC stuff
+import DarkNews as dn
+from DarkNews import logger, prettyprinter
+from DarkNews.AssignmentParser import AssignmentParser
+
+GENERATOR_ARGS = [
+    # scope
+    "decay_product",
+    "experiment",
+    "nopelastic",
+    "nocoh",
+    "include_nelastic",
+    "noHC",
+    "noHF",
+    "nu_flavors",
+    "sample_geometry",
+    "make_summary_plots",
+    "enforce_prompt",
+    #
+    # generator
+    "loglevel",
+    "verbose",
+    "logfile",
+    "neval",
+    "nint",
+    "neval_warmup",
+    "nint_warmup",
+    "seed",
+    #
+    # output
+    "pandas",
+    "parquet",
+    "numpy",
+    "hepevt",
+    "hepevt_legacy",
+    "hepmc2",
+    "hepmc3",
+    "hep_unweight",
+    "unweighted_hep_events",
+    "sparse",
+    "print_to_float32",
+    "path",
+]
+
+COMMON_MODEL_ARGS = [
+    "name",
+    "m4",
+    "m5",
+    "m6",
+    "mzprime",
+    "mhprime",
+    "HNLtype",
+    "mu_tr_e4",
+    "mu_tr_e5",
+    "mu_tr_e6",
+    "mu_tr_mu4",
+    "mu_tr_mu5",
+    "mu_tr_mu6",
+    "mu_tr_tau4",
+    "mu_tr_tau5",
+    "mu_tr_tau6",
+    "mu_tr_44",
+    "mu_tr_45",
+    "mu_tr_46",
+    "mu_tr_55",
+    "mu_tr_56",
+    "s_e4",
+    "s_e5",
+    "s_e6",
+    "s_mu4",
+    "s_mu5",
+    "s_mu6",
+    "s_tau4",
+    "s_tau5",
+    "s_tau6",
+    "s_44",
+    "s_45",
+    "s_46",
+    "s_55",
+    "s_56",
+    "s_66",
+]
+
+THREE_PORTAL_ARGS = [
+    "gD",
+    "epsilon",
+    "alphaD",
+    "epsilon2",
+    "chi",
+    "alpha_epsilon2",
+    "theta",
+    "Ue4",
+    "Ue5",
+    "Ue6",
+    "Umu4",
+    "Umu5",
+    "Umu6",
+    "Utau4",
+    "Utau5",
+    "Utau6",
+    "UD4",
+    "UD5",
+    "UD6",
+]
+
+GENERIC_MODEL_ARGS = [
+    "c_e4",
+    "c_e5",
+    "c_e6",
+    "c_mu4",
+    "c_mu5",
+    "c_mu6",
+    "c_tau4",
+    "c_tau5",
+    "c_tau6",
+    "c_44",
+    "c_45",
+    "c_46",
+    "c_55",
+    "c_56",
+    "c_66",
+    "d_e4",
+    "d_e5",
+    "d_e6",
+    "d_mu4",
+    "d_mu5",
+    "d_mu6",
+    "d_tau4",
+    "d_tau5",
+    "d_tau6",
+    "d_44",
+    "d_45",
+    "d_46",
+    "d_55",
+    "d_56",
+    "d_66",
+    "ceV",
+    "ceA",
+    "cuV",
+    "cuA",
+    "cdV",
+    "cdA",
+    "deV",
+    "deA",
+    "duV",
+    "duA",
+    "ddV",
+    "ddA",
+    "deS",
+    "deP",
+    "duS",
+    "duP",
+    "ddS",
+    "ddP",
+    "cprotonV",
+    "cneutronV",
+    "cprotonA",
+    "cneutronA",
+    "dprotonV",
+    "dneutronV",
+    "dprotonA",
+    "dneutronA",
+    "dprotonS",
+    "dneutronS",
+    "dprotonP",
+    "dneutronP",
+]
+
+class ModelContainer:
+
+    banner = r"""   ______           _        _   _                     
+   |  _  \         | |      | \ | |                    
+   | | | |__ _ _ __| | __   |  \| | _____      _____   
+   | | | / _  | ___| |/ /   | .   |/ _ \ \ /\ / / __|  
+   | |/ / (_| | |  |   <    | |\  |  __/\ V  V /\__ \  
+   |___/ \__,_|_|  |_|\_\   \_| \_/\___| \_/\_/ |___/  """
+
+    # handle parameters that can assume only certain values
+    _choices = {
+        "HNLtype": ["dirac", "majorana"],
+        "decay_product": ["e+e-", "mu+mu-", "photon"],
+        "nu_flavors": ["nu_e", "nu_mu", "nu_tau", "nu_e_bar", "nu_mu_bar", "nu_tau_bar"],
+        "sparse": [0,1,2,3,4],
+    }
+
+    def __init__(self, param_file=None, **kwargs):
+        """ModelContainer creates a set of upscattering and decay processes given user-defined model parameters.
+
+            It instantiates an object to that contains the upscattering and decay processes for the user-defined settings.
+            There are different ways to accomplish this:
+                - file: read the file in input, parsing it looking for the different variables' values;
+                - other arguments: variables' values.
+            If a variable is not provided, it sets the default.
+            at the end it looks inside the kwargs (so kwargs overwrite file definitions).
+
+        Args:
+            param_file (str, optional): path to model file. Defaults to None, which uses the parameters set at run-time.
+            **kwargs: list of user-defined parameters
+
+        Raises:
+            AttributeError: when unused parameters are specified (raise only a
+                warning if unused parameters are specified within the model file).
+            FileNotFoundError: when param_file is specified, but the path is invalid.
+            ValueError: when model, experiment, or generation parameters are not well defined.
+        """
+
+        # Choose what model to initialize
+        captured_3portal_args = set(THREE_PORTAL_ARGS).intersection(kwargs.keys())
+        captured_generic_args = set(GENERIC_MODEL_ARGS).intersection(kwargs.keys())
+        if len(captured_3portal_args) >= 0 and len(captured_generic_args) == 0:
+            logger.info("Initializing the three-portal model.")
+            self._model_parameters = COMMON_MODEL_ARGS + THREE_PORTAL_ARGS
+            self._model_class = dn.model.ThreePortalModel
+        elif len(captured_3portal_args) == 0 and len(captured_generic_args) > 0:
+            logger.info("Initializing a generic model.")
+            self._model_parameters = COMMON_MODEL_ARGS + GENERIC_MODEL_ARGS
+            self._model_class = dn.model.GenericHNLModel
+        elif len(captured_3portal_args) > 0 and len(captured_generic_args) > 0:
+            logger.error(
+                f"Generic Model parameters {captured_generic_args} set at the same time as {captured_3portal_args}. Cannot mix generic and three-portal model arguments together."
+            )
+            raise ValueError("Two types of parameters were found. You cannot mix Generic Model parameters with three-portal Model parameters.")
+        else:
+            raise ValueError(f"Could not determine what model type to use with kwargs.keys = {kwargs.keys()}")
+
+        self._parameters = GENERATOR_ARGS + self._model_parameters
+
+        # Scope parameters
+        self.name = None
+        self.nu_flavors = ["nu_mu"]
+        self.decay_product = "e+e-"
+        self.nuclear_targets = []
+        self.nopelastic = False
+        self.include_nelastic = False
+        self.nocoh = False
+        self.noHC = False
+        self.noHF = False
+        self.sample_geometry = False
+        self.make_summary_plots = False
+        self.enforce_prompt = False
+        
+        # Generator parameters
+        self.loglevel = "INFO"
+        self.verbose = False
+        self.logfile = None
+        self.neval = int(1e4)
+        self.nint = 20
+        self.neval_warmup = int(1e3)
+        self.nint_warmup = 10
+        self.seed = None
+
+        ####################################################
+        # Loading parameters
+
+        # the argument dictionaries (will contain valid arguments extracted from **kwargs)
+        self.model_args_dict = {}
+
+        # load file if not None
+        if param_file is not None:
+            self._load_file(param_file)
+
+        # load constructor parameters
+        self._load_parameters(raise_errors=True, **kwargs)
+
+        ####################################################
+        # Set up loggers
+        self.prettyprinter = prettyprinter
+        self.configure_logger(
+            logger=logger, loglevel=self.loglevel, prettyprinter=self.prettyprinter, verbose=self.verbose, logfile=self.logfile,
+        )
+        prettyprinter.info(self.banner)
+
+        ####################################################
+        # Choose the model to be used in this generation
+        self.bsm_model = self._model_class(**self.model_args_dict)
+
+       ####################################################
+        # MC evaluations and iterations
+        dn.MC.NEVAL_warmup = self.neval_warmup
+        dn.MC.NINT_warmup = self.nint_warmup
+        dn.MC.NEVAL = self.neval
+        dn.MC.NINT = self.nint
+
+        # get the initial projectiles
+        self.projectiles = [getattr(lp, nu) for nu in self.nu_flavors]
+        
+        # decide which helicities to use
+        self.helicities = []
+        if not self.noHC:
+            self.helicities.append('conserving')
+        if not self.noHF:
+            self.helicities.append('flipping')
+
+        ####################################################
+        ## Determine scope of upscattering given the heavy nu spectrum
+        _mass_strings = [f'{m}_{getattr(self.bsm_model, m)}_' for m in ['m6', 'm5', 'm4'] if getattr(self.bsm_model, m) is not None]
+        # 3+1
+        if len(_mass_strings) == 1:
+            self.upscattered_nus = [dn.pdg.neutrino4]
+            self.outgoing_nus = [dn.pdg.nulight]
+        # 3+2
+        elif len(_mass_strings) == 2:
+            ## FIXING 3+2 process chain to be nualpha --> N5 --> N4
+            self.upscattered_nus = [dn.pdg.neutrino5]
+            self.outgoing_nus = [dn.pdg.neutrino4]
+        # 3+3
+        elif len(_mass_strings) == 3:
+            self.upscattered_nus = [dn.pdg.neutrino4, dn.pdg.neutrino5, dn.pdg.neutrino6,
+            ]
+            self.outgoing_nus = [dn.pdg.nulight, dn.pdg.neutrino4, dn.pdg.neutrino5]
+        else:
+            logger.error("Error! Mass spectrum not allowed (m4,m5,m6) = ({self.bsm_model.m4:.4g},{self.bsm_model.m5:.4g},{self.bsm_model.m6:.4g}) GeV.")
+            raise ValueError("Could not find a heavy neutrino spectrum from user input.")
+
+        ####################################################
+        # Create all model cases
+        self._create_all_model_cases()
+        
+        # end __init__
+
+    def _load_file(self, file):
+        parser = AssignmentParser({})
+        try:
+            parser.parse_file(file=file, comments="#")
+        except FileNotFoundError:
+            logger.error(f"Error! File '{file}' not found.")
+            raise
+        # store variables
+        self._load_parameters(raise_errors=False, **parser.parameters)
+
+    def _load_parameters(self, raise_errors=True, **kwargs):
+        # start from the list of parameters available
+        for parameter in self._parameters:
+            # take the value from the kwargs, if not provided, go to next parameter
+            try:
+                value = kwargs.pop(parameter)
+            except KeyError:
+                continue
+            
+            # check the value within the choices
+            # if parameter in self._choices.keys() and value not in self._choices[parameter]:
+            if parameter in self._choices.keys() and [*parameter, *self._choices[parameter],] == set([*parameter, *self._choices[parameter]]):
+                raise ValueError(
+                    f"Parameter '{parameter}', invalid choice: {value}, (choose among " + ", ".join([f"{el}" for el in self._choices[parameter]]) + ")"
+                )
+
+            # set the parameter
+            setattr(self, parameter, value)
+
+            # save the parameters that pertain to the model classes in a dict
+            if parameter in self._model_parameters:
+                self.model_args_dict[parameter] = value
+
+        # at the end, if kwargs is not empty, that would mean some parameters were unused, i.e. they are spelled wrong or do not exist: raise AttributeError
+        if len(kwargs) != 0:
+            if raise_errors:
+                raise AttributeError("Parameters " + ", ".join(kwargs.keys()) + " were unused. Either not supported or misspelled.")
+            else:
+                logger.warning("Parameters " + ", ".join(kwargs.keys()) + " will not be used.")
+
+
+    def _create_all_model_cases(self, **kwargs):
+        """Create MC_events objects and run the MC computations
+
+        Args:
+            **kwargs:
+                FLAVORS (list):             input flavors for projectiles ['nu_e','nu_mu','nu_tau','nu_e_bar','nu_mu_bar','nu_tau_bar']
+                UPSCATTERED_NUS (list):     dark NU in upscattering process
+                OUTFOING_NUS (list):        output flavors
+                SCATTERING_REGIMES (list):  regimes of scattering process (coherent, p-el, n-el)
+                INCLUDE_HC (bool):          flag to include helicity conserving case
+                INCLUDE_HF (bool):          flag to include helicity flipping case
+                NO_COH (bool):              flag to skip coherent case
+                NO_PELASTIC (bool):         flag to skip proton elastic case
+                INCLUDE_NELASTIC (bool):         flag to skip neutron elastic case
+                DECAY_PRODUCTS (list):      decay processes to include
+        """
+
+        # Default values
+        scope = {
+            "NO_COH": self.nocoh,
+            "NO_PELASTIC": self.nopelastic,
+            "INCLUDE_NELASTIC": self.include_nelastic,
+            "HELICITIES": self.helicities,
+            "FLAVORS": self.projectiles,
+            "UPSCATTERED_NUS": self.upscattered_nus,
+            "OUTGOING_NUS": self.outgoing_nus,
+            "DECAY_PRODUCTS": [self.decay_product],
+            "SCATTERING_REGIMES": ["coherent", "p-el"],  # , 'n-el'],
+            "NUCLEAR_TARGETS": self.nuclear_targets,
+        }
+        # override default with kwargs
+        scope.update(kwargs)
+
+        if len(scope["SCATTERING_REGIMES"]) == 0:
+            logger.error("No scattering regime found -- please specify at least one.")
+            raise ValueError
+        if len(scope["DECAY_PRODUCTS"]) == 0:
+            logger.error("No visible decay products found -- please specify at least one final state (e+e-, mu+mu- or photon).")
+            raise ValueError
+        if len(scope["HELICITIES"]) == 0:
+            logger.error("No helicity structure was allowed -- please allow at least one type: HC or HF.")
+            raise ValueError
+        if len(scope["FLAVORS"]) == 0:
+            logger.error("No projectile neutrino flavors specified -- please specify at least one.")
+            raise ValueError
+
+        # create instances of all MC cases of interest
+        logger.debug("Creating instances of MC cases:")
+        self.ups_cases = {}
+        self.dec_cases = {}
+        # neutrino flavor initiating scattering
+        for flavor in scope["FLAVORS"]:
+            # neutrino produced in upscattering
+            for nu_upscattered in scope["UPSCATTERED_NUS"]:
+                # neutrino produced in the subsequent decay
+                for nu_outgoing in scope["OUTGOING_NUS"]:
+                    # final state to consider in decay process
+                    for decay_product in scope["DECAY_PRODUCTS"]:
+                        # skip cases with obviously forbidden decay
+                        if np.abs(nu_outgoing.pdgid) >= np.abs(nu_upscattered.pdgid):
+                            continue
+                        # material on which upscattering happened
+                        for nuclear_target in scope["NUCLEAR_TARGETS"]:
+                            # scattering regime to use
+                            for scattering_regime in scope["SCATTERING_REGIMES"]:
+                                
+                                # skip disallowed regimes
+                                if ((scattering_regime in ["n-el"]) and (nuclear_target.N < 1)) or (  # no neutrons
+                                    (scattering_regime in ["coherent"]) and (not nuclear_target.is_nucleus)
+                                ):  # coherent = p-el for hydrogen
+                                    continue
+                                elif (
+                                    (scattering_regime in ["coherent"] and scope["NO_COH"])\
+                                    or (scattering_regime in ["p-el"] and scope["NO_PELASTIC"])\
+                                    or (scattering_regime in ["n-el"])\
+                                    and (not scope["INCLUDE_NELASTIC"])  # do not include n-el
+                                ):
+                                    continue
+                                else:
+                                    for helicity in scope['HELICITIES']:
+                                        
+                                        # Upscattering process
+                                        ups_args = {
+                                            "nuclear_target": nuclear_target,
+                                            "scattering_regime": scattering_regime,
+                                            "nu_projectile": flavor,
+                                            "nu_upscattered": nu_upscattered,
+                                            "helicity": helicity,
+                                        }
+                                        ups_case = dn.processes.UpscatteringProcess(
+                                            nu_projectile=ups_args["nu_projectile"],
+                                            nu_upscattered=ups_args["nu_upscattered"],
+                                            nuclear_target=ups_args["nuclear_target"],
+                                            scattering_regime=ups_args["scattering_regime"],
+                                            helicity=ups_args["helicity"],
+                                            TheoryModel=self.bsm_model,
+                                        )
+                                        if ups_args not in self.ups_cases.keys():
+                                            self.ups_cases[ups_args] = ups_case
+
+                                        # Decay process
+                                        decay_args = {
+                                            "nu_parent": nu_upscattered,
+                                            "nu_daughter": nu_outgoing,
+                                            "h_parent": ups_case.h_upscattered,
+                                            "decay_product": decay_product,
+                                        }
+                                        if decay_product == "e+e-":
+                                            decay_pdg = dn.pdg.electron
+                                            decays_to_dilepton = True
+                                            decays_to_singlephoton = False
+
+                                        elif decay_product == "mu+mu-":
+                                            decay_pdg = dn.pdg.muon
+                                            decays_to_dilepton = True
+                                            decays_to_singlephoton = False
+
+                                        elif decay_product == "photon":
+                                            decay_pdg = dn.pdg.photon
+                                            decays_to_dilepton = False
+                                            decays_to_singlephoton = True
+
+                                        if decays_to_dilepton:
+                                            decay_case = dn.processes.FermionDileptonDecay(
+                                                nu_parent=decay_args["nu_parent"],
+                                                nu_daughter=decay_args["nu_daughter"],
+                                                final_lepton1=decay_pdg,
+                                                final_lepton2=decay_pdg,
+                                                h_parent=decay_args["h_parent"],
+                                                TheoryModel=self.bsm_model,
+                                            )
+                                        elif decays_to_singlephoton:
+                                            decay_case = dn.processes.FermionSinglePhotonDecay(
+                                                nu_parent=decay_args["nu_parent"],
+                                                nu_daughter=decay_args["nu_daughter"],
+                                                h_parent=decay_args["h_parent"],
+                                                TheoryModel=self.bsm_model,
+                                            )
+                                        else:
+                                            logger.error("Error! Could not determine what type of decay class to use.")
+                                            raise ValueError
+                                        if decay_args not in self.dec_cases.keys():
+                                            self.dec_cases[decay_args] = decay_case
+                                    
+        return self.ups_cases,self.dec_cases
+    
+
+    def configure_logger(
+        self, logger, loglevel=logging.INFO, prettyprinter=None, logfile=None, verbose=False,
+    ):
+        """
+        Configure the DarkNews logger
+
+            logger -->
+
+            prettyprint --> secondary logger for pretty-print messages.
+
+        Args:
+            logger (logging.Logger): main DarkNews logger to be configured.
+                                    It handles all debug, info, warning, and error messages
+
+            loglevel (int, optional): what logging level to use.
+                                    Can be logging.(DEBUG, INFO, WARNING, or ERROR). Defaults to logging.INFO.
+
+            prettyprinter (logging.Logger, optional): if passed, configures this logger for the prettyprint.
+                                                    Cannot override the main logger levelCannot override the main logger level.
+                                                    Defaults to None.
+
+            logfile (str, optional): path to file where to log the output. Defaults to None.
+
+            verbose (bool, optional): If true, keep date and time in the logger format. Defaults to False.
+
+        Raises:
+            ValueError: _description_
+        """
+
+        loglevel = loglevel.upper()
+        _numeric_level = getattr(logging, loglevel, None)
+        if not isinstance(_numeric_level, int):
+            raise ValueError("Invalid log level: %s" % self.loglevel)
+        logger.setLevel(_numeric_level)
+
+        if logfile:
+            # log to files with max 1 MB with up to 4 files of backup
+            handler = logging.handlers.RotatingFileHandler(f"{logfile}", maxBytes=1000000, backupCount=4)
+
+        else:
+            # stdout only
+            handler = logging.StreamHandler(stream=sys.stdout)
+            if prettyprinter:
+                pretty_handler = logging.StreamHandler(stream=sys.stdout)
+                pretty_handler.setLevel(loglevel)
+                delimiter = "---------------------------------------------------------"
+                pretty_handler.setFormatter(logging.Formatter(delimiter + "\n%(message)s\n"))
+                # update pretty printer
+                if prettyprinter.hasHandlers():
+                    prettyprinter.handlers.clear()
+                prettyprinter.addHandler(pretty_handler)
+
+        handler.setLevel(loglevel)
+        if verbose:
+            handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(name)s:\n\t%(message)s\n", datefmt="%H:%M:%S",))
+        else:
+            handler.setFormatter(logging.Formatter("%(message)s"))
+
+        if logger.hasHandlers():
+            logger.handlers.clear()
+        logger.addHandler(handler)

--- a/src/DarkNews/amplitudes.py
+++ b/src/DarkNews/amplitudes.py
@@ -39,7 +39,7 @@ def upscattering_dxsec_dQ2(x_phase_space, process, diagrams=["total"]):
         ValueError: if HNL type not recognized
 
     Returns:
-        numpy.ndarray or dict: either an array with the differential xsec in attobarns at each phase-space point 
+        numpy.ndarray or dict: either an array with the differential xsec in cm2 at each phase-space point 
                 or a dictioary of such values for each diagram.
     """
 
@@ -1215,7 +1215,7 @@ def upscattering_dxsec_dQ2(x_phase_space, process, diagrams=["total"]):
     spin_average = 1 / 2
 
     # final prefactor: dsigma = prefactor*LmunuHmunu
-    prefactor = flux_factor * phase_space * physical_jacobian * spin_average * const.invGeV2_to_attobarn
+    prefactor = flux_factor * phase_space * physical_jacobian * spin_average * const.invGeV2_to_attobarn * const.attobarn_to_cm2
 
     # from amplitude to diff xsec:
     diff_xsec_terms = {}

--- a/src/DarkNews/amplitudes.py
+++ b/src/DarkNews/amplitudes.py
@@ -8,7 +8,7 @@ from DarkNews import logger
 
 def upscattering_dxsec_dQ2(x_phase_space, process, diagrams=["total"]):
     """ 
-    Computes the differential cross section for upscattering in attobarns
+    Computes the differential cross section for upscattering in cm2
 
     Args:
         x_phase_space (list): a list of arrays with [s,t,u] variables

--- a/src/DarkNews/integrands.py
+++ b/src/DarkNews/integrands.py
@@ -97,6 +97,26 @@ class UpscatteringXsec(vg.BatchIntegrand):
 
         return self.int_dic
 
+class HNLDecay(vg.BatchIntegrand):
+    def __init__(self, dim, dec_case, diagram="total"):
+        """
+        Vegas integrand for diff decay width of HNL decay.
+
+        Args:
+                dim (int): integration dimensions
+                dec_case (DarkNews.processes.DecayProcess): the decay class of DarkNews
+                diagram (str, optional): _description_. Defaults to 'total'.
+
+        Raises:
+                ValueError: if cannot find diagrams to be computed
+        """
+        self.dim = dim
+        self.dec_case = dec_case
+        self.diagram = diagram
+        if not isinstance(self.diagram, str):
+            logger.error(f"ERROR. Cannot calculate total decay width for more than one diagram at a time. Passed diagram={self.diagram}.")
+            raise ValueError
+        
 
 class UpscatteringHNLDecay(vg.BatchIntegrand):
     def __init__(self, dim, Emin, Emax, MC_case):

--- a/src/DarkNews/integrands.py
+++ b/src/DarkNews/integrands.py
@@ -9,7 +9,7 @@ from DarkNews import const
 from DarkNews import phase_space
 from DarkNews import decay_rates as dr
 from DarkNews import amplitudes as amps
-from DarkNews import process as proc
+from DarkNews import processes as proc
 
 
 class UpscatteringXsec(vg.BatchIntegrand):
@@ -652,14 +652,14 @@ def get_decay_momenta_from_vegas_samples(vsamples, decay_case, PN_LAB):
     # N boost parameters
     boost_scattered_N = {
         "EP_LAB": PN_LAB[0],
-        "costP_LAB": PN_LAB[3]/np.sqrt(np.sum(PN_LAB[1:3]**2)),
+        "costP_LAB": PN_LAB[3]/np.sqrt(np.sum(PN_LAB[1:]**2)),
         "phiP_LAB": np.arctan2(PN_LAB[2], PN_LAB[1]),
     }
 
     #######################
     # DECAY PROCESSES
 
-    if type(decay_case) == proc.FermionSinglePhotonDecay:
+    if type(decay_case) == proc.FermionDileptonDecay:
 
         mh = decay_case.m_parent
         mf = decay_case.m_daughter
@@ -739,6 +739,7 @@ def get_decay_momenta_from_vegas_samples(vsamples, decay_case, PN_LAB):
 
     elif type(decay_case) == proc.FermionSinglePhotonDecay:
 
+        mh = decay_case.m_parent
         mf = decay_case.m_daughter
 
         ########################

--- a/src/DarkNews/integrands.py
+++ b/src/DarkNews/integrands.py
@@ -651,9 +651,9 @@ def get_decay_momenta_from_vegas_samples(vsamples, decay_case, PN_LAB):
 
     # N boost parameters
     boost_scattered_N = {
-        "EP_LAB": PN_LAB[0],
-        "costP_LAB": PN_LAB[3]/np.sqrt(np.sum(PN_LAB[1:]**2)),
-        "phiP_LAB": np.arctan2(PN_LAB[2], PN_LAB[1]),
+        "EP_LAB": PN_LAB.T[0],
+        "costP_LAB": Cfv.get_cosTheta(PN_LAB),
+        "phiP_LAB": np.arctan2(PN_LAB.T[2], PN_LAB.T[1]),
     }
 
     #######################

--- a/src/DarkNews/integrands.py
+++ b/src/DarkNews/integrands.py
@@ -627,3 +627,134 @@ def get_momenta_from_vegas_samples(vsamples=None, MC_case=None):
         four_momenta["P_decay_photon"] = P3LAB_decay
 
     return four_momenta
+
+def get_decay_momenta_from_vegas_samples(vsamples, decay_case, PN_LAB):
+    """
+    Construct the four momenta of all final state particles in the decay process from the
+    vegas weights.
+
+    Args:
+            vsamples (np.ndarray): integration samples obtained from vegas
+                            as hypercube coordinates. Always in the interval [0,1].
+
+            MC_case (DarkNews.process.dec_case): the decay class of DarkNews
+
+            PN_LAB (np.ndarray): four-momentum of the upscattered N in the lab frame: [E, pX, pY, pZ]
+
+    Returns:
+            dict: each key corresponds to a set of four momenta for a given particle involved,
+                    so the values are 2D np.ndarrays with each row a different event and each column a different
+                    four momentum component. Contains also the weights.
+    """
+
+    four_momenta = {}
+
+    # N boost parameters
+    boost_scattered_N = {
+        "EP_LAB": PN_LAB[0],
+        "costP_LAB": PN_LAB[3]/np.sqrt(np.sum(PN_LAB[1:3]**2)),
+        "phiP_LAB": np.arctan2(PN_LAB[2], PN_LAB[1]),
+    }
+
+    #######################
+    # DECAY PROCESSES
+
+    if type(decay_case) == proc.FermionSinglePhotonDecay:
+
+        mh = decay_case.m_parent
+        mf = decay_case.m_daughter
+        mm = decay_case.mm
+        mp = decay_case.mm
+
+        if decay_case.vector_on_shell or decay_case.scalar_on_shell:
+
+            if decay_case.vector_on_shell and decay_case.scalar_off_shell:
+                m_mediator = decay_case.mzprime
+            elif decay_case.vector_off_shell and decay_case.scalar_on_shell:
+                m_mediator = decay_case.mhprime
+            else:
+                raise NotImplementedError("Both mediators on-shell is not yet implemented.")
+
+            ########################
+            ### HNL decay
+            N_decay_samples = {"unit_cost": np.array(vsamples[0])}
+            # Ni (k1) --> Nj (k2)  Z' (k3)
+            masses_decay = {
+                "m1": mh,  # Ni
+                "m2": mf,  # Nj
+                "m3": m_mediator,  # Z'
+            }
+            # Phnl, Phnl_daughter, Pz'
+            P1LAB_decay, P2LAB_decay, P3LAB_decay = phase_space.two_body_decay(N_decay_samples, boost=boost_scattered_N, **masses_decay)
+
+            # Z' boost parameters
+            boost_Z = {
+                "EP_LAB": P3LAB_decay.T[0],
+                "costP_LAB": Cfv.get_cosTheta(P3LAB_decay),
+                "phiP_LAB": np.arctan2(P3LAB_decay.T[2], P3LAB_decay.T[1]),
+            }
+
+            ########################
+            ### Z' decay
+            Z_decay_samples = {}  # all uniform
+            # Z'(k1) --> ell- (k2)  ell+ (k3)
+            masses_decay = {
+                "m1": m_mediator,  # Ni
+                "m2": mp,  # \ell+
+                "m3": mm,  # \ell-
+            }
+            # PZ', pe-, pe+
+            P1LAB_decayZ, P2LAB_decayZ, P3LAB_decayZ = phase_space.two_body_decay(Z_decay_samples, boost=boost_Z, **masses_decay)
+
+            four_momenta["P_decay_N_parent"] = P1LAB_decay
+            four_momenta["P_decay_N_daughter"] = P2LAB_decay
+            four_momenta["P_decay_ell_minus"] = P2LAB_decayZ
+            four_momenta["P_decay_ell_plus"] = P3LAB_decayZ
+
+        elif decay_case.vector_off_shell and decay_case.scalar_off_shell:
+
+            ########################
+            # HNL decay
+            N_decay_samples = {
+                "unit_t": vsamples[0],
+                "unit_u": vsamples[1],
+                "unit_c3": vsamples[2],
+                "unit_phi34": vsamples[3],
+            }
+
+            # Ni (k1) --> ell-(k2)  ell+(k3)  Nj(k4)
+            masses_decay = {
+                "m1": mh,  # Ni
+                "m2": mm,  # ell-
+                "m3": mp,  # ell+
+                "m4": mf,
+            }  # Nj
+            # Phnl, pe-, pe+, pnu
+            (P1LAB_decay, P2LAB_decay, P3LAB_decay, P4LAB_decay,) = phase_space.three_body_decay(N_decay_samples, boost=boost_scattered_N, **masses_decay)
+
+            four_momenta["P_decay_N_parent"] = P1LAB_decay
+            four_momenta["P_decay_ell_minus"] = P2LAB_decay
+            four_momenta["P_decay_ell_plus"] = P3LAB_decay
+            four_momenta["P_decay_N_daughter"] = P4LAB_decay
+
+    elif type(decay_case) == proc.FermionSinglePhotonDecay:
+
+        mf = decay_case.m_daughter
+
+        ########################
+        ### HNL decay
+        N_decay_samples = {"unit_cost": np.array(vsamples[0])}
+        # Ni (k1) --> Nj (k2)  gamma (k3)
+        masses_decay = {
+            "m1": mh,  # Ni
+            "m2": mf,  # Nj
+            "m3": 0.0,  # gamma
+        }
+        # Phnl, Phnl', Pgamma
+        P1LAB_decay, P2LAB_decay, P3LAB_decay = phase_space.two_body_decay(N_decay_samples, boost=boost_scattered_N, **masses_decay)
+
+        four_momenta["P_decay_N_parent"] = P1LAB_decay
+        four_momenta["P_decay_N_daughter"] = P2LAB_decay
+        four_momenta["P_decay_photon"] = P3LAB_decay
+
+    return four_momenta

--- a/src/DarkNews/processes.py
+++ b/src/DarkNews/processes.py
@@ -140,7 +140,7 @@ class UpscatteringProcess:
 
             #############
             # integrated xsec coverted to cm^2
-            all_xsecs += tot_xsec * const.attobarn_to_cm2 * self.target_multiplicity
+            all_xsecs += tot_xsec * self.target_multiplicity
             logger.debug(f"Total cross section for {diagram} calculated.")
 
         return all_xsecs

--- a/src/DarkNews/processes.py
+++ b/src/DarkNews/processes.py
@@ -156,7 +156,7 @@ class UpscatteringProcess:
         if type(diff_xsecs) is dict:
             return {key: diff_xsecs[key] * physical for key in diff_xsecs.keys()}
         else:
-            return diff_xsecs * physical * const.attobarn_to_cm2 * self.target_multiplicity
+            return diff_xsecs * physical * self.target_multiplicity
 
 
 class FermionDileptonDecay:
@@ -293,12 +293,10 @@ class FermionSinglePhotonDecay:
                 # Save normalization information
                 with open(savefile_norm,'w') as f:
                     json.dump(batch_f.norm, f)
-            integrals = MC.run_vegas(batch_f, integ, adapt_to_errors=True, NINT=NINT, NEVAL=NEVAL, NINT_warmup=NINT_warmup, NEVAL_warmup=NEVAL_warmup, savestr=savefile_xsec)
+            MC.run_vegas(batch_f, integ, adapt_to_errors=True, NINT=NINT, NEVAL=NEVAL, NINT_warmup=NINT_warmup, NEVAL_warmup=NEVAL_warmup, savestr=savefile_dec)
             logger.debug("Main VEGAS run completed.")
             existing_integrator = integ
-        samples = MC.get_samples(existing_integrator, batch_f)
-        return samples
-        
+        return MC.get_samples(existing_integrator, batch_f)
 
     
     def total_width(self):

--- a/src/DarkNews/processes.py
+++ b/src/DarkNews/processes.py
@@ -283,10 +283,10 @@ class FermionSinglePhotonDecay:
         """
         Samples the phase space of the differential decay width in the rest frame of the HNL
         """
+        DIM = 1
+        batch_f = integrands.HNLDecay(dim=DIM, dec_case=self)
         if existing_integrator is None:
             # need to define a new integrator
-            DIM = 1
-            batch_f = integrands.HNLDecay(dim=DIM, dec_case=self)
             integ = vg.Integrator(DIM * [[0.0, 1.0]])  # unit hypercube
 
             if savefile_norm is not None:
@@ -298,7 +298,7 @@ class FermionSinglePhotonDecay:
             logger.debug("Main VEGAS run completed for decay sampler.")
             # Run one more time without adaptation to fix integration points to sample
             # Save the resulting integrator to a pickle file
-            integ(batch_f,integ,adapt=False,NINT=NINT_sample,NEVAL=NEVAL_sample,saveall=savefile_dec)
+            integ(batch_f,adapt=False,nitn=NINT_sample,neval=NEVAL_sample,saveall=savefile_dec)
             existing_integrator = integ
         return MC.get_samples(existing_integrator, batch_f)
 

--- a/src/DarkNews/processes.py
+++ b/src/DarkNews/processes.py
@@ -279,7 +279,7 @@ class FermionSinglePhotonDecay:
         else:
             self.Tih = self.TheoryModel.t_aj[pdg.get_HNL_index(nu_daughter), pdg.get_HNL_index(nu_parent)]
 
-    def SamplePS(self, NINT=MC.NINT, NEVAL=MC.NEVAL, NINT_warmup=MC.NINT_warmup, NEVAL_warmup=MC.NEVAL_warmup, existing_integrator=None, savefile_norm=None, savefile_dec=None):
+    def SamplePS(self, NINT=MC.NINT, NEVAL=MC.NEVAL, NINT_warmup=MC.NINT_warmup, NEVAL_warmup=MC.NEVAL_warmup, NINT_sample=1, NEVAL_sample=10_000, savefile_norm=None, savefile_dec=None, existing_integrator=None):
         """
         Samples the phase space of the differential decay width in the rest frame of the HNL
         """
@@ -293,8 +293,12 @@ class FermionSinglePhotonDecay:
                 # Save normalization information
                 with open(savefile_norm,'w') as f:
                     json.dump(batch_f.norm, f)
-            MC.run_vegas(batch_f, integ, adapt_to_errors=True, NINT=NINT, NEVAL=NEVAL, NINT_warmup=NINT_warmup, NEVAL_warmup=NEVAL_warmup, savestr=savefile_dec)
-            logger.debug("Main VEGAS run completed.")
+            # run the integrator
+            MC.run_vegas(batch_f, integ, adapt_to_errors=True, NINT=NINT, NEVAL=NEVAL, NINT_warmup=NINT_warmup, NEVAL_warmup=NEVAL_warmup)
+            logger.debug("Main VEGAS run completed for decay sampler.")
+            # Run one more time without adaptation to fix integration points to sample
+            # Save the resulting integrator to a pickle file
+            integ(batch_f,integ,adapt=False,NINT=NINT_sample,NEVAL=NEVAL_sample,saveall=savefile_dec)
             existing_integrator = integ
         return MC.get_samples(existing_integrator, batch_f)
 

--- a/src/DarkNews/processes.py
+++ b/src/DarkNews/processes.py
@@ -250,7 +250,7 @@ class FermionDileptonDecay:
             logger.error("Vector and scalar simultaneously on shell is not implemented.")
             raise NotImplementedError("Feature not implemented.")
         elif (self.vector_off_shell and self.scalar_on_shell) or \
-             (self.vector_off_shell and self.scalar_on_shell):
+             (self.vector_on_shell and self.scalar_off_shell):
             DIM = 1
         elif self.vector_off_shell and self.scalar_off_shell:
             DIM = 4

--- a/src/DarkNews/processes.py
+++ b/src/DarkNews/processes.py
@@ -10,6 +10,7 @@ from DarkNews import MC
 from DarkNews import model
 from DarkNews import amplitudes as amps
 from DarkNews import phase_space as ps
+from DarkNews import decay_rates as dr
 
 
 class UpscatteringProcess:
@@ -263,6 +264,18 @@ class FermionSinglePhotonDecay:
         else:
             self.Tih = self.TheoryModel.t_aj[pdg.get_HNL_index(nu_daughter), pdg.get_HNL_index(nu_parent)]
 
+    def total_width(self):
+        return dr.gamma_Ni_to_Nj_gamma(self.Tih,
+                                       self.m_parent,
+                                       self.m_daughter,
+                                       HNLType=self.HNLtype)
+    
+    def differential_width(self, cost):
+        return dr.diff_gamma_Ni_to_Nj_gamma(cost,
+                                            self.Tih,
+                                            self.m_parent,
+                                            self.m_daughter,
+                                            HNLType=self.HNLtype)
 
 def find_calculable_diagrams(bsm_model):
     """ 


### PR DESCRIPTION
This pull request adds a few features to DarkNews to enable compatibility with [LeptonInjector](https://github.com/Harvard-Neutrino/LeptonInjector). Updates include:

- adding a `ModelContainer` class for LeptonInjector to collect the upscattering and decay cases of interest without creating a GenLauncher object
- More support for standalone decays (rather than upscattering+decay), including an `HNLDecay` integrand class and a `get_decay_momenta_from_vegas_samples` to sample the outgoing four momenta of an isolated decay process. Have also implemented `SamplePS`, `total_width`, and `differential_width` methods for `FermionDileptonDecay` and `FermionSinglePhotonDecay` classes
- Various lambda functions changed to partial functions or named functions to allow serialization via pickle on the LeptonInjector end
- Added functionality to save pickled versions of the vegas integrators for upscattering and decay processes
- changed units used by the amplitudes class to report cross sections in cm^2 rather than ab, since this is what LI directly accesses. Conversions modified elsewhere in code to be consistent with this change