### PR TITLE
logger and prettyprinter no longer exposed at module level

### DIFF
--- a/src/DarkNews/ModelContainer.py
+++ b/src/DarkNews/ModelContainer.py
@@ -6,7 +6,8 @@ from particle import literals as lp
 
 # Dark Neutrino and MC stuff
 import DarkNews as dn
-from DarkNews import logger, prettyprinter
+logger = logging.getLogger("logger." + __name__)
+prettyprinter = logging.getLogger("prettyprinter." + __name__)
 from DarkNews.AssignmentParser import AssignmentParser
 from DarkNews.nuclear_tools import NuclearTarget
 


### PR DESCRIPTION
The `logger` and `prettyprinter` objects are no longer exposed at the DarkNews module level and so need to be grabbed through the `logging` module just like in other files.