### PR TITLE
Fixed u and t calculation

### DIFF
--- a/src/DarkNews/processes.py
+++ b/src/DarkNews/processes.py
@@ -388,10 +388,10 @@ class FermionDileptonDecay:
             # Ni (k1) --> ell-(k2)  ell+(k3)  Nj(k4)
 
             # t = m23^2
-            t = Cfv.dot4(Plepminus_LAB, Plepplus_LAB)
+            t = self.mm**2 + self.mp**2 + 2.0 * Cfv.dot4(Plepminus_LAB, Plepplus_LAB)
 
             # u = m24^2
-            u = Cfv.dot4(Plepminus_LAB, Pnu_LAB)
+            u = self.mm**2 + self.m_daughter**2 + 2.0 * Cfv.dot4(Plepminus_LAB, Pnu_LAB)
 
             # c3 = cosine of polar angle of k3
             # Boost ell+ to HNL rest frame


### PR DESCRIPTION
This PR fixes the calculation of the Mandelstam variables `t` and `u` in `differential_width`. Previously, these quantities were computed using only the four-vector dot products. The updated expressions now include the appropriate particle mass terms:

* $$t=m_-^2 + m_+^2 + 2p_-\cdot p_+$$
*  $$u=m_-^2 + m_{daughter}^2 + 2p_-\cdot p_\nu$$

This makes the implementation consistent with the invariant-mass definitions.